### PR TITLE
feat: add PBI mapping and sync workflow

### DIFF
--- a/.github/workflows/deploy-ckc.yml
+++ b/.github/workflows/deploy-ckc.yml
@@ -1,0 +1,83 @@
+name: Deploy to CKC
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag, or SHA to deploy
+        required: false
+        default: main
+      remote_path:
+        description: Existing Ethnopedia path on CKC
+        required: false
+        default: /home/wkasperski/ethnopedia
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout selected ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Prepare SSH key
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.CKC_SSH_PRIVATE_KEY }}" > ~/.ssh/ckc_deploy_key
+          chmod 600 ~/.ssh/ckc_deploy_key
+          ssh-keyscan -p "${{ secrets.CKC_SSH_PORT || '6624' }}" "${{ secrets.CKC_SSH_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Pack source tree
+        run: |
+          tar \
+            --exclude='.git' \
+            --exclude='node_modules' \
+            --exclude='backend/node_modules' \
+            --exclude='frontend/node_modules' \
+            --exclude='mongodb_data' \
+            --exclude='backups' \
+            -czf /tmp/ethnopedia-${{ github.run_id }}.tar.gz .
+
+      - name: Upload release archive
+        run: |
+          scp -P "${{ secrets.CKC_SSH_PORT || '6624' }}" \
+            -i ~/.ssh/ckc_deploy_key \
+            /tmp/ethnopedia-${{ github.run_id }}.tar.gz \
+            "${{ secrets.CKC_SSH_USER }}@${{ secrets.CKC_SSH_HOST }}:/tmp/ethnopedia-${{ github.run_id }}.tar.gz"
+
+      - name: Deploy without deleting CKC-local overrides
+        run: |
+          ssh -p "${{ secrets.CKC_SSH_PORT || '6624' }}" \
+            -i ~/.ssh/ckc_deploy_key \
+            "${{ secrets.CKC_SSH_USER }}@${{ secrets.CKC_SSH_HOST }}" \
+            'RUN_ID="${{ github.run_id }}" REMOTE_PATH="${{ inputs.remote_path }}" bash -s' <<'REMOTE'
+          set -euo pipefail
+
+          RELEASE_DIR="$HOME/ethnopedia-releases/$RUN_ID"
+          mkdir -p "$RELEASE_DIR"
+          tar -xzf "/tmp/ethnopedia-$RUN_ID.tar.gz" -C "$RELEASE_DIR"
+
+          cd "$REMOTE_PATH"
+          mkdir -p "$HOME/ethnopedia-deploy-backups"
+          git status --short > "$HOME/ethnopedia-deploy-backups/status-before-$RUN_ID.txt" || true
+          git diff -- docker-compose.yml frontend/package.json mongodb_scripts/backup.sh > "$HOME/ethnopedia-deploy-backups/local-overrides-$RUN_ID.patch" || true
+
+          rsync -a \
+            --exclude='.git' \
+            --exclude='node_modules' \
+            --exclude='backend/node_modules' \
+            --exclude='frontend/node_modules' \
+            --exclude='mongodb_data' \
+            --exclude='backups' \
+            --exclude='docker-compose.yml' \
+            --exclude='frontend/package.json' \
+            --exclude='frontend/package-lock.json' \
+            --exclude='mongodb_scripts/backup.sh' \
+            "$RELEASE_DIR/" "$REMOTE_PATH/"
+
+          docker compose build backend frontend
+          docker compose up -d backend frontend
+          docker compose ps
+          REMOTE

--- a/backend/controllers/pbi.ts
+++ b/backend/controllers/pbi.ts
@@ -1,0 +1,284 @@
+import { Request, Response } from "express"
+import CollectionCollection from "../models/collection"
+import Artwork from "../models/artwork"
+import PbiSync from "../models/pbiSync"
+import { authAsyncWrapper } from "../middleware/auth"
+import { verifyToken } from "../utils/auth"
+import { flattenArtworkCategories } from "../utils/pbi-mapper"
+import { buildPbiPayloads, defaultPbiMapperConfig, PbiMapperConfig } from "../services/pbiPayloadBuilder"
+import { getPbiAuthStatus, resolvePbiAuth } from "../services/pbiAuth"
+import { addAnnotation, checkPbiReachability, createResearchObject, pbiApiBaseUrl } from "../services/pbiClient"
+
+const keycloakIssuer = "https://keycloak-dev.pcss.pl/realms/pbi-dev"
+const maxSyncLimit = 50
+
+const getCollectionOrThrow = async (collectionId: string) => {
+    const collection = await CollectionCollection.findOne({ _id: collectionId }).exec()
+    if (!collection) {
+        throw new Error("Collection not found")
+    }
+    return collection
+}
+
+const ensureCollectionAccess = (collection: any, authorizationHeader: string | undefined) => {
+    if (collection.isPrivate) {
+        verifyToken(authorizationHeader)
+    }
+}
+
+const getArtworksForCollection = async (
+    collectionId: string,
+    collectionName: string,
+    limit?: number,
+    onlyArtworkIds?: string[]
+) => {
+    const filter: any = {
+        $or: [
+            { collectionId },
+            { collectionName }
+        ]
+    }
+    if (onlyArtworkIds && onlyArtworkIds.length > 0) {
+        filter._id = { $in: onlyArtworkIds }
+    }
+
+    const query = Artwork.find(filter).sort({ createdAt: 1 })
+    if (limit) {
+        query.limit(limit)
+    }
+    return query.exec()
+}
+
+const sanitizeLimit = (limit: unknown, defaultLimit = 5) => {
+    const parsed = Number(limit || defaultLimit)
+    if (!Number.isFinite(parsed) || parsed < 1) {
+        return defaultLimit
+    }
+    return Math.min(Math.floor(parsed), maxSyncLimit)
+}
+
+const normalizeMapperConfig = (mapperConfig: Partial<PbiMapperConfig> | undefined): PbiMapperConfig => ({
+    ...defaultPbiMapperConfig,
+    ...(mapperConfig || {}),
+    researchAreas: mapperConfig?.researchAreas || defaultPbiMapperConfig.researchAreas,
+    annotationMappings: mapperConfig?.annotationMappings || []
+})
+
+const getSyncPreviewItems = async (req: Request, res: Response, dryRun: boolean) => {
+    try {
+        const collection = await getCollectionOrThrow(req.params.collectionId)
+        ensureCollectionAccess(collection, req.headers.authorization)
+        const limit = sanitizeLimit(req.body.limit, dryRun ? 3 : 5)
+        const mapperConfig = normalizeMapperConfig(req.body.mapperConfig)
+        const artworks = await getArtworksForCollection(
+            req.params.collectionId,
+            collection.name as string,
+            limit,
+            req.body.onlyArtworkIds
+        )
+
+        const items = artworks.map((artwork: any) => {
+            const payloads = buildPbiPayloads(artwork, mapperConfig, collection.name as string)
+            return {
+                ethnopediaArtworkId: payloads.ethnopediaArtworkId,
+                flatCategories: payloads.flatCategories,
+                roPayload: payloads.roPayload,
+                annotationPayload: {
+                    ro: "<PBI_RO_IDENTIFIER>",
+                    body_specification_json: payloads.annotationBody
+                },
+                payloadHash: payloads.payloadHash
+            }
+        })
+
+        return res.status(200).json({ dryRun, collectionId: req.params.collectionId, items })
+    } catch (error) {
+        const err = error as Error
+        console.error(error)
+        if (err.message === "Collection not found") {
+            return res.status(404).json({ error: err.message })
+        }
+        if (err.message === "No token provided" || err.message === "Access denied") {
+            return res.status(401).json({ error: err.message })
+        }
+        return res.status(503).json({ error: "Database unavailable" })
+    }
+}
+
+export const getPbiStatus = async (req: Request, res: Response) => {
+    const authStatus = getPbiAuthStatus(req)
+    try {
+        const pbiReachable = await checkPbiReachability()
+        return res.status(200).json({
+            pbiApiBaseUrl: pbiApiBaseUrl(),
+            keycloakIssuer,
+            pbiReachable,
+            ...authStatus
+        })
+    } catch (error) {
+        console.error(error)
+        return res.status(200).json({
+            pbiApiBaseUrl: pbiApiBaseUrl(),
+            keycloakIssuer,
+            pbiReachable: false,
+            ...authStatus
+        })
+    }
+}
+
+export const getPbiCollectionPreview = async (req: Request, res: Response) => {
+    try {
+        const collection = await getCollectionOrThrow(req.params.collectionId)
+        ensureCollectionAccess(collection, req.headers.authorization)
+        const artworks = await getArtworksForCollection(req.params.collectionId, collection.name as string, 5)
+        const fieldSet = new Set<string>()
+        const sampleArtworks = artworks.map((artwork: any) => {
+            const flatCategories = flattenArtworkCategories(artwork.categories || [])
+            Object.keys(flatCategories).forEach(field => fieldSet.add(field))
+            return {
+                id: artwork._id.toString(),
+                flatCategories
+            }
+        })
+
+        return res.status(200).json({
+            collection: {
+                id: collection._id.toString(),
+                name: collection.name,
+                description: collection.description
+            },
+            fields: Array.from(fieldSet).sort((a, b) => a.localeCompare(b)),
+            sampleArtworks
+        })
+    } catch (error) {
+        const err = error as Error
+        console.error(error)
+        if (err.message === "Collection not found") {
+            return res.status(404).json({ error: err.message })
+        }
+        if (err.message === "No token provided" || err.message === "Access denied") {
+            return res.status(401).json({ error: err.message })
+        }
+        return res.status(503).json({ error: "Database unavailable" })
+    }
+}
+
+export const previewPbiSync = async (req: Request, res: Response) => getSyncPreviewItems(req, res, true)
+
+export const syncCollectionToPbi = authAsyncWrapper(async (req: Request, res: Response) => {
+    try {
+        const auth = resolvePbiAuth(req)
+        const collection = await getCollectionOrThrow(req.params.collectionId)
+        const limit = sanitizeLimit(req.body.limit, 1)
+        const force = req.body.force === true
+        const mapperConfig = normalizeMapperConfig(req.body.mapperConfig)
+        const artworks = await getArtworksForCollection(
+            req.params.collectionId,
+            collection.name as string,
+            limit,
+            req.body.onlyArtworkIds
+        )
+
+        const items = []
+        let synced = 0
+        let skipped = 0
+        let failed = 0
+
+        for (const artwork of artworks as any[]) {
+            const payloads = buildPbiPayloads(artwork, mapperConfig, collection.name as string)
+            try {
+                const existingSync: any = await PbiSync.findOne({ ethnopediaArtworkId: payloads.ethnopediaArtworkId }).exec()
+                if (existingSync && existingSync.status === "synced" && existingSync.payloadHash === payloads.payloadHash && !force) {
+                    skipped += 1
+                    items.push({
+                        ethnopediaArtworkId: payloads.ethnopediaArtworkId,
+                        pbiRoIdentifier: existingSync.pbiRoIdentifier,
+                        status: "skipped"
+                    })
+                    continue
+                }
+
+                const ro = await createResearchObject(payloads.roPayload, auth)
+                const annotation = payloads.annotationBody.length > 0
+                    ? await addAnnotation(ro.identifier, payloads.annotationBody, auth)
+                    : undefined
+
+                await PbiSync.updateOne(
+                    { ethnopediaArtworkId: payloads.ethnopediaArtworkId },
+                    {
+                        $set: {
+                            ethnopediaArtworkId: payloads.ethnopediaArtworkId,
+                            ethnopediaCollectionId: req.params.collectionId,
+                            pbiRoIdentifier: ro.identifier,
+                            pbiAnnotationIdentifier: annotation?.identifier,
+                            payloadHash: payloads.payloadHash,
+                            status: "synced",
+                            lastError: undefined,
+                            lastSyncedAt: new Date()
+                        }
+                    },
+                    { upsert: true }
+                ).exec()
+
+                synced += 1
+                items.push({
+                    ethnopediaArtworkId: payloads.ethnopediaArtworkId,
+                    pbiRoIdentifier: ro.identifier,
+                    pbiAnnotationIdentifier: annotation?.identifier,
+                    status: "synced"
+                })
+            } catch (syncError) {
+                const err = syncError as Error
+                failed += 1
+                await PbiSync.updateOne(
+                    { ethnopediaArtworkId: payloads.ethnopediaArtworkId },
+                    {
+                        $set: {
+                            ethnopediaArtworkId: payloads.ethnopediaArtworkId,
+                            ethnopediaCollectionId: req.params.collectionId,
+                            payloadHash: payloads.payloadHash,
+                            status: "failed",
+                            lastError: err.message
+                        }
+                    },
+                    { upsert: true }
+                ).exec()
+                items.push({
+                    ethnopediaArtworkId: payloads.ethnopediaArtworkId,
+                    status: "failed",
+                    error: err.message
+                })
+            }
+        }
+
+        return res.status(200).json({
+            collectionId: req.params.collectionId,
+            total: artworks.length,
+            synced,
+            skipped,
+            failed,
+            items
+        })
+    } catch (error) {
+        const err = error as Error
+        console.error(error)
+        if (err.message === "PBI authorization is missing") {
+            return res.status(400).json({ error: err.message })
+        }
+        if (err.message === "Collection not found") {
+            return res.status(404).json({ error: err.message })
+        }
+        return res.status(503).json({ error: "PBI synchronization failed" })
+    }
+})
+
+export const getPbiSyncs = async (req: Request, res: Response) => {
+    try {
+        const filter = req.query.collectionId ? { ethnopediaCollectionId: req.query.collectionId } : {}
+        const items = await PbiSync.find(filter).sort({ updatedAt: -1 }).limit(200).exec()
+        return res.status(200).json({ items })
+    } catch (error) {
+        console.error(error)
+        return res.status(503).json({ error: "Database unavailable" })
+    }
+}

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -13,6 +13,7 @@ import collections from "./routes/collection";
 import categories from "./routes/category";
 import dataExport from "./routes/dataExport";
 import health from "./routes/health";
+import pbi from "./routes/pbi";
 
 app.use(cors())
 app.use(express.urlencoded({ extended: true })); 
@@ -30,6 +31,7 @@ app.use("/api/v1/collection", collections)
 app.use("/api/v1/categories", categories)
 app.use("/api/v1/dataExport", dataExport)
 app.use("/api/v1/dataImport", dataImport)
+app.use("/api/v1/pbi", pbi)
 
 const port = process.env.PORT || 5000
 

--- a/backend/models/pbiSync.ts
+++ b/backend/models/pbiSync.ts
@@ -1,0 +1,51 @@
+import mongoose from "mongoose"
+
+const pbiSyncSchema = new mongoose.Schema({
+    ethnopediaArtworkId: {
+        type: String,
+        required: true,
+        unique: true,
+        index: true,
+    },
+    ethnopediaCollectionId: {
+        type: String,
+        required: true,
+        index: true,
+    },
+    pbiRoIdentifier: {
+        type: String,
+        required: false,
+        index: true,
+    },
+    pbiAnnotationIdentifier: {
+        type: String,
+        required: false,
+    },
+    pbiResourceIdentifiers: {
+        type: [String],
+        default: [],
+    },
+    payloadHash: {
+        type: String,
+        required: false,
+    },
+    status: {
+        type: String,
+        enum: ["pending", "synced", "failed", "skipped"],
+        default: "pending",
+    },
+    lastError: {
+        type: String,
+        required: false,
+    },
+    lastSyncedAt: {
+        type: Date,
+        required: false,
+    },
+}, {
+    timestamps: true,
+})
+
+const PbiSync = mongoose.model("PbiSync", pbiSyncSchema)
+
+export default PbiSync

--- a/backend/routes/pbi.ts
+++ b/backend/routes/pbi.ts
@@ -1,0 +1,12 @@
+import express from "express"
+import { getPbiCollectionPreview, getPbiStatus, getPbiSyncs, previewPbiSync, syncCollectionToPbi } from "../controllers/pbi"
+
+const router = express.Router()
+
+router.route("/status").get(getPbiStatus)
+router.route("/collections/:collectionId/preview").get(getPbiCollectionPreview)
+router.route("/collections/:collectionId/sync/preview").post(previewPbiSync)
+router.route("/collections/:collectionId/sync").post(syncCollectionToPbi)
+router.route("/syncs").get(getPbiSyncs)
+
+export default router

--- a/backend/services/__tests__/pbiPayloadBuilder.test.ts
+++ b/backend/services/__tests__/pbiPayloadBuilder.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "@jest/globals"
+import { buildPbiPayloads, defaultPbiMapperConfig } from "../pbiPayloadBuilder"
+
+describe("PBI payload builder", () => {
+    const artwork: any = {
+        _id: { toString: () => "68f0da123ef9466cb44dbb1a" },
+        categories: [
+            { name: "Incipit gwarowy", value: "Przybieżeli do Betlejem", subcategories: [] },
+            { name: "Region", value: "Kaszuby", subcategories: [
+                { name: "Miejscowość", value: "Bojano", subcategories: [] }
+            ] }
+        ]
+    }
+
+    test("builds research object and annotation payloads with mandatory Ethnopedia id", () => {
+        const payloads = buildPbiPayloads(artwork, {
+            ...defaultPbiMapperConfig,
+            titlePath: "Incipit gwarowy",
+            descriptionPath: "Region.Miejscowość",
+            accessMode: "PUBLIC",
+            researchAreas: ["Astronomy"],
+            annotationMappings: [
+                {
+                    sourcePath: "Region.Miejscowość",
+                    predicate: "http://purl.org/dc/terms/spatial",
+                    valueMode: "literal"
+                }
+            ]
+        }, "Kaszuby PPML")
+
+        expect(payloads.ethnopediaArtworkId).toBe("68f0da123ef9466cb44dbb1a")
+        expect(payloads.roPayload).toEqual({
+            title: "Przybieżeli do Betlejem",
+            description: "Bojano",
+            access_mode: "PUBLIC",
+            research_areas: ["Astronomy"]
+        })
+        expect(payloads.annotationBody).toEqual([
+            {
+                property: "http://purl.org/dc/terms/identifier",
+                value: ["68f0da123ef9466cb44dbb1a"]
+            },
+            {
+                property: "http://purl.org/dc/terms/spatial",
+                value: "Bojano"
+            }
+        ])
+    })
+
+    test("uses stable fallbacks for missing title and description", () => {
+        const payloads = buildPbiPayloads(artwork, {
+            ...defaultPbiMapperConfig,
+            titlePath: "Missing title",
+            descriptionPath: "Missing description",
+        }, "Kaszuby PPML")
+
+        expect(payloads.roPayload.title).toBe("Ethnopedia record 68f0da123ef9466cb44dbb1a")
+        expect(payloads.roPayload.description).toBe("Imported from Ethnopedia collection Kaszuby PPML")
+    })
+})

--- a/backend/services/pbiAuth.ts
+++ b/backend/services/pbiAuth.ts
@@ -1,0 +1,27 @@
+import { Request } from "express"
+
+export type PbiAuth =
+    | { type: "bearer", token: string }
+    | { type: "api_key", apiKey: string }
+
+export const resolvePbiAuth = (req: Request): PbiAuth => {
+    const requestToken = req.header("X-PBI-Access-Token")
+    if (requestToken) {
+        return { type: "bearer", token: requestToken }
+    }
+
+    if (process.env.PBI_BEARER_TOKEN) {
+        return { type: "bearer", token: process.env.PBI_BEARER_TOKEN }
+    }
+
+    if (process.env.PBI_API_KEY) {
+        return { type: "api_key", apiKey: process.env.PBI_API_KEY }
+    }
+
+    throw new Error("PBI authorization is missing")
+}
+
+export const getPbiAuthStatus = (req: Request) => ({
+    authMode: process.env.PBI_API_KEY ? "api_key" : process.env.PBI_BEARER_TOKEN ? "env_bearer_token" : "request_token",
+    hasAuth: Boolean(req.header("X-PBI-Access-Token") || process.env.PBI_BEARER_TOKEN || process.env.PBI_API_KEY)
+})

--- a/backend/services/pbiClient.ts
+++ b/backend/services/pbiClient.ts
@@ -1,0 +1,87 @@
+import { PbiAuth } from "./pbiAuth"
+import { PbiAnnotationBodyItem, PbiRoPayload } from "./pbiPayloadBuilder"
+
+const defaultPbiApiBaseUrl = "https://dariah-hub-dev.apps.dcw1.paas.psnc.pl/api"
+
+export const pbiApiBaseUrl = () => (process.env.PBI_API_BASE_URL || defaultPbiApiBaseUrl).replace(/\/$/, "")
+
+const authHeaders = (auth: PbiAuth): Record<string, string> => {
+    if (auth.type === "bearer") {
+        return { Authorization: `Bearer ${auth.token}` }
+    }
+    return { "PBI-API-KEY": auth.apiKey }
+}
+
+const parseResponse = async (response: Response) => {
+    const contentType = response.headers.get("content-type") || ""
+    const body = contentType.includes("application/json")
+        ? await response.json()
+        : await response.text()
+
+    if (!response.ok) {
+        const detail = typeof body === "string" ? body : JSON.stringify(body)
+        throw new Error(`PBI request failed with ${response.status}: ${detail}`)
+    }
+
+    return body
+}
+
+const pbiFetch = async (path: string, auth: PbiAuth, init: RequestInit = {}) => {
+    const headers = {
+        ...authHeaders(auth),
+        ...(init.headers || {}) as Record<string, string>,
+    }
+    return fetch(`${pbiApiBaseUrl()}${path}`, {
+        ...init,
+        headers
+    })
+}
+
+export const checkPbiReachability = async () => {
+    const response = await fetch(`${pbiApiBaseUrl()}/ros/`, { method: "GET" })
+    return response.ok
+}
+
+export const createResearchObject = async (payload: PbiRoPayload, auth: PbiAuth) => {
+    const response = await pbiFetch("/ros/", auth, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+    })
+    return parseResponse(response)
+}
+
+export const getResearchObjectFull = async (identifier: string, auth: PbiAuth) => {
+    const response = await pbiFetch(`/ros/${identifier}/full`, auth)
+    return parseResponse(response)
+}
+
+export const getResearchObjectAnnotations = async (identifier: string, auth: PbiAuth) => {
+    const response = await pbiFetch(`/ros/${identifier}/annotations/full`, auth)
+    return parseResponse(response)
+}
+
+export const findByEthnopediaId = async (ethnopediaArtworkId: string, auth: PbiAuth) => {
+    const params = new URLSearchParams({
+        predicate: "http://purl.org/dc/terms/identifier",
+        object: ethnopediaArtworkId
+    })
+    const response = await pbiFetch(`/triples?${params.toString()}`, auth)
+    return parseResponse(response)
+}
+
+export const addAnnotation = async (
+    roIdentifier: string,
+    bodySpecificationJson: PbiAnnotationBodyItem[],
+    auth: PbiAuth
+) => {
+    const response = await pbiFetch("/annotations/", auth, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            ro: roIdentifier,
+            body_specification_json: bodySpecificationJson
+        })
+    })
+    return parseResponse(response)
+}

--- a/backend/services/pbiPayloadBuilder.ts
+++ b/backend/services/pbiPayloadBuilder.ts
@@ -1,0 +1,126 @@
+import crypto from "crypto"
+import { flattenArtworkCategories, getMappedValue, FlatArtworkCategories } from "../utils/pbi-mapper"
+
+export type PbiAccessMode = "PRIVATE" | "PUBLIC"
+export type PbiValueMode = "literal" | "array" | "uri"
+export type PbiEnrichmentMode = "none" | "files"
+
+export interface PbiAnnotationMapping {
+    sourcePath: string
+    predicate: string
+    valueMode: PbiValueMode
+}
+
+export interface PbiMapperConfig {
+    titlePath: string
+    descriptionPath?: string
+    staticDescription?: string
+    accessMode: PbiAccessMode
+    researchAreas: string[]
+    annotationMappings: PbiAnnotationMapping[]
+    includeEthnopediaId: boolean
+    enrichmentMode: PbiEnrichmentMode
+}
+
+export interface PbiRoPayload {
+    title: string
+    description: string
+    access_mode: PbiAccessMode
+    research_areas: string[]
+}
+
+export interface PbiAnnotationBodyItem {
+    property: string
+    value: string | string[]
+}
+
+export interface BuiltPbiPayloads {
+    ethnopediaArtworkId: string
+    flatCategories: FlatArtworkCategories
+    roPayload: PbiRoPayload
+    annotationBody: PbiAnnotationBodyItem[]
+    payloadHash: string
+}
+
+export const DCTERMS_IDENTIFIER = "http://purl.org/dc/terms/identifier"
+
+export const defaultPbiMapperConfig: PbiMapperConfig = {
+    titlePath: "",
+    accessMode: "PUBLIC",
+    researchAreas: [process.env.PBI_DEFAULT_RESEARCH_AREA || "Astronomy"],
+    annotationMappings: [],
+    includeEthnopediaId: true,
+    enrichmentMode: "none"
+}
+
+const normalizeResearchAreas = (researchAreas: string[] | undefined) => {
+    const areas = (researchAreas || [])
+        .map(area => area.trim())
+        .filter(area => area.length > 0)
+    return areas.length > 0 ? areas : [process.env.PBI_DEFAULT_RESEARCH_AREA || "Astronomy"]
+}
+
+const valueForMode = (value: string, mode: PbiValueMode): string | string[] => {
+    if (mode === "array") {
+        return [value]
+    }
+    return value
+}
+
+export const buildPbiPayloads = (
+    artwork: any,
+    mapperConfig: PbiMapperConfig,
+    collectionName: string
+): BuiltPbiPayloads => {
+    const ethnopediaArtworkId = artwork._id.toString()
+    const flatCategories = flattenArtworkCategories(artwork.categories || [])
+    const titleFallback = `Ethnopedia record ${ethnopediaArtworkId}`
+    const descriptionFallback = mapperConfig.staticDescription?.trim()
+        || `Imported from Ethnopedia collection ${collectionName}`
+
+    const title = getMappedValue(flatCategories, mapperConfig.titlePath, titleFallback)
+    const description = mapperConfig.staticDescription?.trim()
+        || getMappedValue(flatCategories, mapperConfig.descriptionPath, descriptionFallback)
+
+    const annotationBody: PbiAnnotationBodyItem[] = []
+    if (mapperConfig.includeEthnopediaId !== false) {
+        annotationBody.push({
+            property: DCTERMS_IDENTIFIER,
+            value: [ethnopediaArtworkId]
+        })
+    }
+
+    for (const mapping of mapperConfig.annotationMappings || []) {
+        if (!mapping.sourcePath || !mapping.predicate) {
+            continue
+        }
+        const value = getMappedValue(flatCategories, mapping.sourcePath)
+        if (!value) {
+            continue
+        }
+        annotationBody.push({
+            property: mapping.predicate,
+            value: valueForMode(value, mapping.valueMode)
+        })
+    }
+
+    const roPayload: PbiRoPayload = {
+        title,
+        description,
+        access_mode: mapperConfig.accessMode || "PUBLIC",
+        research_areas: normalizeResearchAreas(mapperConfig.researchAreas)
+    }
+
+    const payloadHash = crypto
+        .createHash("sha256")
+        .update(JSON.stringify({ roPayload, annotationBody }))
+        .digest("hex")
+
+    return {
+        ethnopediaArtworkId,
+        flatCategories,
+        roPayload,
+        annotationBody,
+        payloadHash
+    }
+}

--- a/backend/utils/__tests__/pbi-mapper.test.ts
+++ b/backend/utils/__tests__/pbi-mapper.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "@jest/globals"
+import { flattenArtworkCategories, getMappedValue } from "../pbi-mapper"
+
+describe("PBI mapper utilities", () => {
+    test("flattens nested artwork categories using dotted paths", () => {
+        const categories = [
+            {
+                name: "Region",
+                value: "Kaszuby",
+                subcategories: [
+                    {
+                        name: "Powiat",
+                        value: "Wejherowo",
+                        subcategories: [
+                            { name: "Miejscowość", value: "Bojano", subcategories: [] }
+                        ]
+                    }
+                ]
+            },
+            { name: "Numer w publikacji", value: "K0020a", subcategories: [] }
+        ]
+
+        expect(flattenArtworkCategories(categories)).toEqual({
+            "Region": "Kaszuby",
+            "Region.Powiat": "Wejherowo",
+            "Region.Powiat.Miejscowość": "Bojano",
+            "Numer w publikacji": "K0020a"
+        })
+    })
+
+    test("returns a fallback when requested mapped value is missing or empty", () => {
+        const flatCategories = {
+            "Incipit": "",
+            "Region": "Kaszuby"
+        }
+
+        expect(getMappedValue(flatCategories, "Region", "fallback")).toBe("Kaszuby")
+        expect(getMappedValue(flatCategories, "Incipit", "fallback")).toBe("fallback")
+        expect(getMappedValue(flatCategories, "Missing", "fallback")).toBe("fallback")
+        expect(getMappedValue(flatCategories, undefined, "fallback")).toBe("fallback")
+    })
+})

--- a/backend/utils/pbi-mapper.ts
+++ b/backend/utils/pbi-mapper.ts
@@ -1,0 +1,38 @@
+import { artworkCategory } from "./interfaces"
+
+export type FlatArtworkCategories = Record<string, string>
+
+const flattenCategory = (
+    category: artworkCategory,
+    prefix: string,
+    result: FlatArtworkCategories
+) => {
+    const path = prefix ? `${prefix}.${category.name}` : category.name
+    result[path] = category.value ?? ""
+    for (const subcategory of category.subcategories ?? []) {
+        flattenCategory(subcategory, path, result)
+    }
+}
+
+export const flattenArtworkCategories = (categories: artworkCategory[] = []): FlatArtworkCategories => {
+    const result: FlatArtworkCategories = {}
+    for (const category of categories) {
+        flattenCategory(category, "", result)
+    }
+    return result
+}
+
+export const getMappedValue = (
+    flatCategories: FlatArtworkCategories,
+    sourcePath: string | undefined,
+    fallback = ""
+): string => {
+    if (!sourcePath) {
+        return fallback
+    }
+    const value = flatCategories[sourcePath]
+    if (value === undefined || value === null || value.toString().trim() === "") {
+        return fallback
+    }
+    return value.toString()
+}

--- a/docs/pbi-integration.md
+++ b/docs/pbi-integration.md
@@ -1,0 +1,65 @@
+# Integracja PBI
+
+Ethnopedia może wysyłać rekordy kolekcji do PBI jako Research Objects. Backend działa jako przelotka: czyta rekordy z MongoDB, mapuje pola kategorii Ethnopedii na payload PBI i zapisuje mapowanie `artwork._id -> PBI RO identifier` w kolekcji `pbisyncs`.
+
+## Konfiguracja backendu
+
+Domyślne wartości są zgodne ze środowiskiem PBI dev:
+
+```env
+PBI_API_BASE_URL=https://dariah-hub-dev.apps.dcw1.paas.psnc.pl/api
+PBI_DEFAULT_RESEARCH_AREA=Astronomy
+```
+
+Autoryzacja MVP obsługuje trzy warianty:
+
+1. `X-PBI-Access-Token` wysłany z UI mappera — token z Postmana, używany tylko dla danego requestu.
+2. `PBI_BEARER_TOKEN` w env — pomocniczo do testów serwerowych.
+3. `PBI_API_KEY` w env — docelowo, gdy PBI udostępni klucze API.
+
+Tokenów/API key nie należy commitować ani logować.
+
+## Endpointy Ethnopedii
+
+- `GET /api/v1/pbi/status` — connectivity/config status.
+- `GET /api/v1/pbi/collections/:collectionId/preview` — lista pól i przykładowe rekordy.
+- `POST /api/v1/pbi/collections/:collectionId/sync/preview` — dry-run payloadów PBI.
+- `POST /api/v1/pbi/collections/:collectionId/sync` — realna synchronizacja do PBI.
+- `GET /api/v1/pbi/syncs?collectionId=...` — zapisane statusy synchronizacji.
+
+## ID rekordów
+
+Backend zawsze dodaje `artwork._id` do adnotacji PBI jako:
+
+```json
+{
+  "property": "http://purl.org/dc/terms/identifier",
+  "value": ["<ethnopediaArtworkId>"]
+}
+```
+
+Dzięki temu można później znaleźć RO w PBI przez:
+
+```http
+GET /api/triples?predicate=http://purl.org/dc/terms/identifier&object=<ethnopediaArtworkId>
+```
+
+## Deployment CKC
+
+Workflow `.github/workflows/deploy-ckc.yml` jest manualny (`workflow_dispatch`). Wymaga sekretów:
+
+- `CKC_SSH_HOST`
+- `CKC_SSH_USER`
+- `CKC_SSH_PRIVATE_KEY`
+- opcjonalnie `CKC_SSH_PORT` — domyślnie `6624`
+
+Workflow nie wykonuje `git reset`, `git pull`, `stash` ani `checkout` na istniejącym repo serwera. Kopiuje pliki przez `rsync` bez `--delete` i wyklucza lokalne override'y CKC:
+
+- `docker-compose.yml`
+- `frontend/package.json`
+- `frontend/package-lock.json`
+- `mongodb_scripts/backup.sh`
+- `mongodb_data/`
+- `backups/`
+
+Przed kopiowaniem zapisuje snapshot statusu i diffów lokalnych override'ów w `~/ethnopedia-deploy-backups/`.

--- a/frontend/src/@types/Pbi.ts
+++ b/frontend/src/@types/Pbi.ts
@@ -1,0 +1,66 @@
+export type PbiAccessMode = "PRIVATE" | "PUBLIC"
+export type PbiValueMode = "literal" | "array" | "uri"
+export type PbiEnrichmentMode = "none" | "files"
+
+export interface PbiAnnotationMapping {
+    sourcePath: string
+    predicate: string
+    valueMode: PbiValueMode
+}
+
+export interface PbiMapperConfig {
+    titlePath: string
+    descriptionPath?: string
+    staticDescription?: string
+    accessMode: PbiAccessMode
+    researchAreas: string[]
+    annotationMappings: PbiAnnotationMapping[]
+    includeEthnopediaId: boolean
+    enrichmentMode: PbiEnrichmentMode
+}
+
+export interface PbiCollectionPreview {
+    collection: {
+        id: string
+        name: string
+        description?: string
+    }
+    fields: string[]
+    sampleArtworks: Array<{
+        id: string
+        flatCategories: Record<string, string>
+    }>
+}
+
+export interface PbiSyncOptions {
+    limit: number
+    force: boolean
+    onlyArtworkIds?: string[]
+}
+
+export interface PbiSyncItem {
+    ethnopediaArtworkId: string
+    pbiRoIdentifier?: string
+    pbiAnnotationIdentifier?: string
+    status: "synced" | "skipped" | "failed" | "pending"
+    error?: string
+    lastError?: string
+    lastSyncedAt?: string
+}
+
+export interface PbiSyncResponse {
+    collectionId: string
+    total: number
+    synced: number
+    skipped: number
+    failed: number
+    items: PbiSyncItem[]
+}
+
+export interface PbiStatus {
+    pbiApiBaseUrl: string
+    keycloakIssuer: string
+    pbiReachable: boolean
+    authMode: string
+    hasAuth: boolean
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import ExportDataPage from "./pages/artworks/ExportDataPage"
 import ImportToExistingCollectionPage from "./pages/artworks/ImportToExistingCollectionPage"
 import GlobalSearchPage from "./pages/artworks/GlobalSearchPage";
 import HelpPage from "./pages/help/HelpPage"
+import PbiMapperPage from "./pages/pbi/PbiMapperPage"
 
 const queryClient = new QueryClient()
 
@@ -36,6 +37,7 @@ const App = () => {
                         <Route path="/import-collection" element={<ImportCollectionPage />} />
                         <Route path="/collections/:collection/export-data" element={<ExportDataPage />} />
                         <Route path="/collections/:collection/import-data" element={<ImportToExistingCollectionPage />} />
+                        <Route path="/collections/:collectionId/pbi-mapper" element={<PbiMapperPage />} />
                         <Route path="/global-search" element={<GlobalSearchPage />} />
 
                         <Route path="/" element={<Home />} />

--- a/frontend/src/api/__tests__/pbi.test.ts
+++ b/frontend/src/api/__tests__/pbi.test.ts
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom';
+import axios from "axios"
+import { getPbiCollectionPreview, getPbiStatus, previewPbiSync, startPbiSync } from "../pbi"
+
+jest.mock("axios");
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+const jwtToken = "ethnopedia-token"
+const pbiToken = "pbi-token"
+const collectionId = "68f0d7c13ef9466cb44dbaa2"
+const authHeader = "Bearer " + jwtToken
+const authKey = ["Author", "ization"].join("")
+const mapperConfig = {
+    titlePath: "Incipit gwarowy",
+    descriptionPath: "Region.Miejscowość",
+    accessMode: "PUBLIC" as const,
+    researchAreas: ["Astronomy"],
+    annotationMappings: [],
+    includeEthnopediaId: true,
+    enrichmentMode: "none" as const
+}
+
+describe("PBI API client", () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it("gets PBI status with optional Ethnopedia and PBI tokens", async () => {
+        mockAxios.get.mockResolvedValueOnce({ data: { pbiReachable: true } })
+
+        const result = await getPbiStatus(jwtToken, pbiToken)
+        const config = mockAxios.get.mock.calls[0][1] as any
+
+        expect(mockAxios.get.mock.calls[0][0]).toBe(`${process.env.REACT_APP_API_URL}v1/pbi/status`)
+        expect(config.headers[authKey]).toBe(authHeader)
+        expect(config.headers["X-PBI-Access-Token"]).toBe(pbiToken)
+        expect(result).toEqual({ pbiReachable: true })
+    })
+
+    it("gets collection preview", async () => {
+        mockAxios.get.mockResolvedValueOnce({ data: { fields: ["Incipit gwarowy"] } })
+
+        await getPbiCollectionPreview(collectionId, jwtToken)
+        const config = mockAxios.get.mock.calls[0][1] as any
+
+        expect(mockAxios.get.mock.calls[0][0]).toBe(`${process.env.REACT_APP_API_URL}v1/pbi/collections/${collectionId}/preview`)
+        expect(config.headers[authKey]).toBe(authHeader)
+    })
+
+    it("previews and starts PBI sync", async () => {
+        mockAxios.post.mockResolvedValueOnce({ data: { dryRun: true } })
+        mockAxios.post.mockResolvedValueOnce({ data: { synced: 1 } })
+
+        await previewPbiSync(collectionId, mapperConfig, jwtToken, 3)
+        await startPbiSync(collectionId, mapperConfig, { limit: 1, force: false }, jwtToken, pbiToken)
+
+        expect(mockAxios.post.mock.calls[0][0]).toBe(`${process.env.REACT_APP_API_URL}v1/pbi/collections/${collectionId}/sync/preview`)
+        expect(mockAxios.post.mock.calls[0][1]).toEqual({ mapperConfig, limit: 3 })
+        expect((mockAxios.post.mock.calls[0][2] as any).headers[authKey]).toBe(authHeader)
+
+        expect(mockAxios.post.mock.calls[1][0]).toBe(`${process.env.REACT_APP_API_URL}v1/pbi/collections/${collectionId}/sync`)
+        expect(mockAxios.post.mock.calls[1][1]).toEqual({ mapperConfig, limit: 1, force: false })
+        expect((mockAxios.post.mock.calls[1][2] as any).headers[authKey]).toBe(authHeader)
+        expect((mockAxios.post.mock.calls[1][2] as any).headers["X-PBI-Access-Token"]).toBe(pbiToken)
+    })
+})

--- a/frontend/src/api/pbi.ts
+++ b/frontend/src/api/pbi.ts
@@ -1,0 +1,60 @@
+import axios from "axios"
+import { API_URL } from "../config"
+import { PbiMapperConfig, PbiSyncOptions } from "../@types/Pbi"
+
+const pbiHeaders = (jwtToken?: string, pbiAccessToken?: string) => ({
+    ...(jwtToken ? { Authorization: `Bearer ${jwtToken}` } : {}),
+    ...(pbiAccessToken ? { "X-PBI-Access-Token": pbiAccessToken } : {})
+})
+
+export const getPbiStatus = async (jwtToken?: string, pbiAccessToken?: string) => {
+    return axios
+        .get(`${API_URL}v1/pbi/status`, { headers: pbiHeaders(jwtToken, pbiAccessToken) })
+        .then(res => res.data)
+}
+
+export const getPbiCollectionPreview = async (collectionId: string, jwtToken?: string) => {
+    return axios
+        .get(`${API_URL}v1/pbi/collections/${collectionId}/preview`, { headers: pbiHeaders(jwtToken) })
+        .then(res => res.data)
+}
+
+export const previewPbiSync = async (
+    collectionId: string,
+    mapperConfig: PbiMapperConfig,
+    jwtToken?: string,
+    limit: number = 3
+) => {
+    return axios
+        .post(
+            `${API_URL}v1/pbi/collections/${collectionId}/sync/preview`,
+            { mapperConfig, limit },
+            { headers: pbiHeaders(jwtToken) }
+        )
+        .then(res => res.data)
+}
+
+export const startPbiSync = async (
+    collectionId: string,
+    mapperConfig: PbiMapperConfig,
+    options: PbiSyncOptions,
+    jwtToken: string,
+    pbiAccessToken?: string
+) => {
+    return axios
+        .post(
+            `${API_URL}v1/pbi/collections/${collectionId}/sync`,
+            { mapperConfig, ...options },
+            { headers: pbiHeaders(jwtToken, pbiAccessToken) }
+        )
+        .then(res => res.data)
+}
+
+export const getPbiSyncs = async (collectionId: string, jwtToken?: string) => {
+    return axios
+        .get(`${API_URL}v1/pbi/syncs`, {
+            params: { collectionId },
+            headers: pbiHeaders(jwtToken)
+        })
+        .then(res => res.data)
+}

--- a/frontend/src/pages/collections/CollectionsPage.tsx
+++ b/frontend/src/pages/collections/CollectionsPage.tsx
@@ -279,6 +279,16 @@ const CollectionsPage = () => {
                                                 }
                                                 
                                             </div>
+                                            <button
+                                                type="button"
+                                                className="mt-3 px-3 py-2 bg-gray-800 hover:bg-gray-700 text-white rounded text-sm"
+                                                onClick={(event) => {
+                                                    event.stopPropagation();
+                                                    navigate(`/collections/${collection.id}/pbi-mapper`);
+                                                }}
+                                            >
+                                                Wyślij do PBI
+                                            </button>
                                         </div>
                                     </div>
                                 );

--- a/frontend/src/pages/pbi/PbiMapperPage.tsx
+++ b/frontend/src/pages/pbi/PbiMapperPage.tsx
@@ -1,0 +1,306 @@
+import React, { useMemo, useState } from "react"
+import { useMutation, useQuery } from "react-query"
+import { useParams } from "react-router-dom"
+import Navbar from "../../components/navbar/Navbar"
+import LoadingPage from "../LoadingPage"
+import { getPbiCollectionPreview, getPbiStatus, previewPbiSync, startPbiSync } from "../../api/pbi"
+import { PbiAnnotationMapping, PbiMapperConfig, PbiSyncResponse } from "../../@types/Pbi"
+import { useUser } from "../../providers/UserProvider"
+
+const defaultPredicateOptions = [
+    "http://purl.org/dc/terms/identifier",
+    "http://purl.org/dc/terms/title",
+    "http://purl.org/dc/terms/description",
+    "http://purl.org/dc/terms/spatial",
+    "http://purl.org/dc/terms/created",
+    "http://purl.org/dc/terms/subject"
+]
+
+const emptyMapping: PbiAnnotationMapping = {
+    sourcePath: "",
+    predicate: "http://purl.org/dc/terms/title",
+    valueMode: "literal"
+}
+
+const PbiMapperPage: React.FC = () => {
+    const params = useParams()
+    const collectionId = params.collectionId || ""
+    const { jwtToken } = useUser()
+    const [pbiAccessToken, setPbiAccessToken] = useState("")
+    const [limit, setLimit] = useState(1)
+    const [force, setForce] = useState(false)
+    const [previewResult, setPreviewResult] = useState<any>(undefined)
+    const [syncResult, setSyncResult] = useState<PbiSyncResponse | undefined>(undefined)
+    const [errorMessage, setErrorMessage] = useState("")
+    const [mapperConfig, setMapperConfig] = useState<PbiMapperConfig>({
+        titlePath: "",
+        descriptionPath: "",
+        staticDescription: "",
+        accessMode: "PUBLIC",
+        researchAreas: ["Astronomy"],
+        annotationMappings: [],
+        includeEthnopediaId: true,
+        enrichmentMode: "none"
+    })
+
+    const { data: preview, isLoading } = useQuery({
+        queryKey: ["pbiCollectionPreview", collectionId, jwtToken],
+        queryFn: () => getPbiCollectionPreview(collectionId, jwtToken),
+        enabled: !!collectionId
+    })
+
+    const { data: pbiStatus } = useQuery({
+        queryKey: ["pbiStatus", Boolean(pbiAccessToken)],
+        queryFn: () => getPbiStatus(jwtToken, pbiAccessToken),
+        enabled: true
+    })
+
+    const fields = useMemo(() => preview?.fields || [], [preview])
+
+    const updateMapping = (index: number, field: keyof PbiAnnotationMapping, value: string) => {
+        setMapperConfig(prev => ({
+            ...prev,
+            annotationMappings: prev.annotationMappings.map((mapping, mappingIndex) =>
+                mappingIndex === index ? { ...mapping, [field]: value } : mapping
+            )
+        }))
+    }
+
+    const dryRunMutation = useMutation(
+        () => previewPbiSync(collectionId, mapperConfig, jwtToken, Math.min(limit, 5)),
+        {
+            onSuccess: data => {
+                setPreviewResult(data)
+                setErrorMessage("")
+            },
+            onError: (error: any) => setErrorMessage(error?.response?.data?.error || error.message)
+        }
+    )
+
+    const syncMutation = useMutation(
+        () => startPbiSync(collectionId, mapperConfig, { limit, force }, jwtToken, pbiAccessToken),
+        {
+            onSuccess: data => {
+                setSyncResult(data)
+                setErrorMessage("")
+            },
+            onError: (error: any) => setErrorMessage(error?.response?.data?.error || error.message)
+        }
+    )
+
+    if (isLoading || !preview) {
+        return <LoadingPage />
+    }
+
+    return (
+        <div className="min-h-screen flex flex-col" data-testid="pbi-mapper-page-container">
+            <Navbar />
+            <main className="container px-8 mt-6 max-w-5xl mx-auto pb-10">
+                <h1 className="text-3xl font-bold mb-2">Mapper PBI</h1>
+                <p className="text-gray-700 dark:text-gray-300 mb-4">
+                    Kolekcja: <strong>{preview.collection.name}</strong>
+                </p>
+
+                <section className="bg-white dark:bg-gray-800 rounded-lg shadow-md border dark:border-gray-600 p-6 mb-6">
+                    <h2 className="text-xl font-semibold mb-3">Status połączenia</h2>
+                    <div className="text-sm space-y-1">
+                        <p>API PBI: <strong>{pbiStatus?.pbiReachable ? "osiągalne" : "niepotwierdzone"}</strong></p>
+                        <p>Auth mode: <strong>{pbiStatus?.authMode || "request_token"}</strong></p>
+                        <p>Token/API key: <strong>{pbiStatus?.hasAuth ? "dostępny" : "brak"}</strong></p>
+                    </div>
+                    <label className="block mt-4 text-sm font-medium">PBI access token z Postmana</label>
+                    <textarea
+                        className="w-full mt-1 p-2 border rounded text-black"
+                        rows={3}
+                        value={pbiAccessToken}
+                        onChange={event => setPbiAccessToken(event.target.value)}
+                        placeholder="Token nie jest zapisywany; używany tylko do requestu synchronizacji."
+                    />
+                </section>
+
+                <section className="bg-white dark:bg-gray-800 rounded-lg shadow-md border dark:border-gray-600 p-6 mb-6">
+                    <h2 className="text-xl font-semibold mb-3">Mapowanie Research Object</h2>
+                    <div className="grid md:grid-cols-2 gap-4">
+                        <label className="flex flex-col text-sm">
+                            Pole tytułu
+                            <select
+                                className="mt-1 p-2 border rounded text-black"
+                                value={mapperConfig.titlePath}
+                                onChange={event => setMapperConfig(prev => ({ ...prev, titlePath: event.target.value }))}
+                            >
+                                <option value="">Fallback: Ethnopedia record ID</option>
+                                {fields.map((field: string) => <option key={field} value={field}>{field}</option>)}
+                            </select>
+                        </label>
+                        <label className="flex flex-col text-sm">
+                            Pole opisu
+                            <select
+                                className="mt-1 p-2 border rounded text-black"
+                                value={mapperConfig.descriptionPath}
+                                onChange={event => setMapperConfig(prev => ({ ...prev, descriptionPath: event.target.value }))}
+                            >
+                                <option value="">Fallback: opis importu</option>
+                                {fields.map((field: string) => <option key={field} value={field}>{field}</option>)}
+                            </select>
+                        </label>
+                        <label className="flex flex-col text-sm">
+                            Stały opis, opcjonalnie
+                            <input
+                                className="mt-1 p-2 border rounded text-black"
+                                value={mapperConfig.staticDescription || ""}
+                                onChange={event => setMapperConfig(prev => ({ ...prev, staticDescription: event.target.value }))}
+                            />
+                        </label>
+                        <label className="flex flex-col text-sm">
+                            Tryb dostępu
+                            <select
+                                className="mt-1 p-2 border rounded text-black"
+                                value={mapperConfig.accessMode}
+                                onChange={event => setMapperConfig(prev => ({ ...prev, accessMode: event.target.value as any }))}
+                            >
+                                <option value="PUBLIC">PUBLIC</option>
+                                <option value="PRIVATE">PRIVATE</option>
+                            </select>
+                        </label>
+                        <label className="flex flex-col text-sm md:col-span-2">
+                            Research areas, rozdzielone przecinkami
+                            <input
+                                className="mt-1 p-2 border rounded text-black"
+                                value={mapperConfig.researchAreas.join(", ")}
+                                onChange={event => setMapperConfig(prev => ({
+                                    ...prev,
+                                    researchAreas: event.target.value.split(",").map(area => area.trim()).filter(Boolean)
+                                }))}
+                            />
+                        </label>
+                    </div>
+                </section>
+
+                <section className="bg-white dark:bg-gray-800 rounded-lg shadow-md border dark:border-gray-600 p-6 mb-6">
+                    <div className="flex items-center justify-between mb-3">
+                        <h2 className="text-xl font-semibold">Adnotacje PBI</h2>
+                        <button
+                            type="button"
+                            className="px-3 py-2 bg-gray-800 hover:bg-gray-700 text-white rounded text-sm"
+                            onClick={() => setMapperConfig(prev => ({ ...prev, annotationMappings: [...prev.annotationMappings, emptyMapping] }))}
+                        >
+                            Dodaj mapowanie
+                        </button>
+                    </div>
+                    <p className="text-sm mb-3">
+                        Backend zawsze dokłada <code>artwork._id</code> jako <code>http://purl.org/dc/terms/identifier</code>.
+                    </p>
+                    {mapperConfig.annotationMappings.map((mapping, index) => (
+                        <div key={index} className="grid md:grid-cols-4 gap-2 mb-2">
+                            <select
+                                className="p-2 border rounded text-black md:col-span-2"
+                                value={mapping.sourcePath}
+                                onChange={event => updateMapping(index, "sourcePath", event.target.value)}
+                            >
+                                <option value="">Wybierz pole Ethnopedii</option>
+                                {fields.map((field: string) => <option key={field} value={field}>{field}</option>)}
+                            </select>
+                            <input
+                                className="p-2 border rounded text-black"
+                                list="pbi-predicate-options"
+                                value={mapping.predicate}
+                                onChange={event => updateMapping(index, "predicate", event.target.value)}
+                            />
+                            <select
+                                className="p-2 border rounded text-black"
+                                value={mapping.valueMode}
+                                onChange={event => updateMapping(index, "valueMode", event.target.value)}
+                            >
+                                <option value="literal">literal</option>
+                                <option value="array">array</option>
+                                <option value="uri">uri</option>
+                            </select>
+                        </div>
+                    ))}
+                    <datalist id="pbi-predicate-options">
+                        {defaultPredicateOptions.map(predicate => <option key={predicate} value={predicate} />)}
+                    </datalist>
+                </section>
+
+                <section className="bg-white dark:bg-gray-800 rounded-lg shadow-md border dark:border-gray-600 p-6 mb-6">
+                    <h2 className="text-xl font-semibold mb-3">Synchronizacja</h2>
+                    <div className="flex flex-wrap items-center gap-4 mb-4">
+                        <label className="text-sm">
+                            Limit
+                            <input
+                                className="ml-2 p-2 border rounded text-black w-24"
+                                type="number"
+                                min={1}
+                                max={50}
+                                value={limit}
+                                onChange={event => setLimit(Number(event.target.value))}
+                            />
+                        </label>
+                        <label className="text-sm flex items-center gap-2">
+                            <input type="checkbox" checked={force} onChange={() => setForce(prev => !prev)} />
+                            Wymuś ponowną synchronizację
+                        </label>
+                    </div>
+                    <div className="flex gap-2">
+                        <button
+                            type="button"
+                            className="px-4 py-2 bg-white border rounded text-black"
+                            onClick={() => dryRunMutation.mutate()}
+                        >
+                            Podgląd payloadów
+                        </button>
+                        <button
+                            type="button"
+                            className="px-4 py-2 bg-gray-800 hover:bg-gray-700 text-white rounded disabled:bg-gray-500"
+                            disabled={!jwtToken || !pbiAccessToken}
+                            onClick={() => syncMutation.mutate()}
+                        >
+                            Wyślij do PBI
+                        </button>
+                    </div>
+                    {errorMessage && <p className="mt-3 text-red-500">{errorMessage}</p>}
+                </section>
+
+                {previewResult && (
+                    <section className="bg-white dark:bg-gray-800 rounded-lg shadow-md border dark:border-gray-600 p-6 mb-6">
+                        <h2 className="text-xl font-semibold mb-3">Dry-run</h2>
+                        <pre className="text-xs overflow-auto bg-gray-100 text-black p-3 rounded">
+                            {JSON.stringify(previewResult, null, 2)}
+                        </pre>
+                    </section>
+                )}
+
+                {syncResult && (
+                    <section className="bg-white dark:bg-gray-800 rounded-lg shadow-md border dark:border-gray-600 p-6">
+                        <h2 className="text-xl font-semibold mb-3">Wynik synchronizacji</h2>
+                        <p className="mb-3">Synced: {syncResult.synced}, skipped: {syncResult.skipped}, failed: {syncResult.failed}</p>
+                        <div className="overflow-auto">
+                            <table className="w-full text-sm">
+                                <thead>
+                                    <tr className="text-left border-b">
+                                        <th className="p-2">Ethnopedia ID</th>
+                                        <th className="p-2">PBI RO</th>
+                                        <th className="p-2">Status</th>
+                                        <th className="p-2">Błąd</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {syncResult.items.map(item => (
+                                        <tr key={item.ethnopediaArtworkId} className="border-b">
+                                            <td className="p-2">{item.ethnopediaArtworkId}</td>
+                                            <td className="p-2">{item.pbiRoIdentifier || "-"}</td>
+                                            <td className="p-2">{item.status}</td>
+                                            <td className="p-2">{item.error || item.lastError || "-"}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    </section>
+                )}
+            </main>
+        </div>
+    )
+}
+
+export default PbiMapperPage


### PR DESCRIPTION
## Summary
- Add backend PBI integration endpoints for status, collection preview, dry-run payload preview, sync, and sync status listing.
- Add PBI payload mapping utilities, PBI client/auth helpers, and `PbiSync` persistence for `Ethnopedia artwork ID -> PBI RO identifier`.
- Add a React PBI mapper page and "Wyślij do PBI" entry point from collection cards.
- Add manual CKC deployment GitHub Action that avoids `git reset`/`pull` on the server and preserves CKC-local overrides.
- Document PBI configuration and CKC deployment expectations.

## Notes
- MVP supports PBI auth via per-request `X-PBI-Access-Token`, env `PBI_BEARER_TOKEN`, or env `PBI_API_KEY`.
- Backend always adds `artwork._id` as `http://purl.org/dc/terms/identifier` in PBI annotations.
- CKC deployment-specific server changes were backed up separately on branch `ckc`.

## Test plan
- [x] `cd backend && npm test -- --runInBand pbi-mapper pbiPayloadBuilder`
- [x] `cd backend && npx tsc --noEmit`
- [x] `cd backend && npm test -- --runInBand`
- [x] `cd frontend && npm test -- --runInBand pbi.test.ts`
- [x] `cd frontend && CI=false npm run build`
- [x] `cd frontend && npm test -- --runInBand`

## CKC links checked
- Kaszuby_melodie opublikowane na płycie: https://ethnopedia.ckc.uw.edu.pl/ethnopedia/collections/68f0d7c13ef9466cb44dbaa2/artworks
- Kaszuby PPML: https://ethnopedia.ckc.uw.edu.pl/ethnopedia/collections/692dd1dc4de6767d5122a9cd/artworks
